### PR TITLE
Avoid logging stack trace repeatedly

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -263,7 +263,7 @@ def do_network_api():
     # Create the sockets
     rep_socket = zmq_context.socket(zmq.REP)
     rep_socket.bind("tcp://*:9903")
-    rep_socket.RCVTIMEO = 5000
+    rep_socket.RCVTIMEO = 15000
 
     pub_socket = zmq_context.socket(zmq.PUB)
     pub_socket.bind("tcp://*:9904")
@@ -294,7 +294,7 @@ def do_network_api():
 
         except zmq.error.Again:
             # Timeout - press on.
-            log.exception("Got an error")
+            log.debug("No data received")
 
         # Reload config file just in case, before we send all the data.
         load_files(config_path)


### PR DESCRIPTION
The logs in question were benign, but we made them every 5 seconds (rather than every 15), and they were way too scary for a log that really meant "nothing has happened, so continue".