### PR TITLE
Increase plugin timeouts to 10s to allow for slow VMs.

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -134,8 +134,8 @@ def do_ep_api():
     # Create the EP REP socket
     resync_socket = zmq_context.socket(zmq.REP)
     resync_socket.bind("tcp://*:9901")
-    resync_socket.SNDTIMEO = 5000
-    resync_socket.RCVTIMEO = 5000
+    resync_socket.SNDTIMEO = 10000
+    resync_socket.RCVTIMEO = 10000
     log.debug("Created EP socket for resync")
 
     # We create an EP REQ socket each time we get a connection from another
@@ -208,8 +208,8 @@ def send_all_eps(create_sockets, host, resync_id):
 
     if create_socket is None:
         create_socket = zmq_context.socket(zmq.REQ)
-        create_socket.SNDTIMEO = 5000
-        create_socket.RCVTIMEO = 5000
+        create_socket.SNDTIMEO = 10000
+        create_socket.RCVTIMEO = 10000
         create_socket.connect("tcp://%s:9902" % felix_ip[host])
         create_sockets[host] = create_socket
 


### PR DESCRIPTION
We were seeing VMs actually take 5s to respond, so worth increasing the limit a bit.

Fixes issue #22.
