### PR TITLE
Send keepalives on network API if no data.

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -280,6 +280,16 @@ def do_network_api():
         # Now send all the data we have on the PUB socket.
         log.debug("Build data to publish")
 
+        if not all_groups:
+            # No groups to send; send a keepalive instead so ACL Manager
+            # doesn't think we have gone away.
+            msg = {"type": "HEARTBEAT",
+                   "issued": int(time.time()* 1000)}
+            log.debug("Sending network heartbeat %s", msg)
+            pub_socket.send_multipart(['networkheartbeat'.encode('utf-8'),
+                                       json.dumps(msg).encode('utf-8')])
+
+
         for group in all_groups:
             members = all_groups[group]
 


### PR DESCRIPTION
The issue was that if there was no data to send, the plugin would send nothing, and the ACL Manager would restart. That's benign, but looks awful, so fix it.