### PR TITLE
Cl3 traceroute

### DIFF
--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:14.04
 
 RUN apt-get update
-RUN apt-get install -y python-zmq iptables ipset wget telnet curl man
+RUN apt-get install -y python-zmq iptables ipset wget telnet curl man traceroute

--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:14.04
 
 RUN apt-get update
-RUN apt-get install -y python-zmq iptables ipset wget telnet curl man traceroute
+RUN apt-get install -y python-zmq iptables ipset wget telnet curl man traceroute iperf netcat


### PR DESCRIPTION
This addresses issue #28.  Tested change to calico:util Dockerfile.  Added apt-get for iperf, traceroute, and netcat.
